### PR TITLE
Capture build logs

### DIFF
--- a/datalad_debian/bootstrap_builder.py
+++ b/datalad_debian/bootstrap_builder.py
@@ -72,7 +72,7 @@ class BootstrapBuilder(Interface):
         yield from builder_ds.run(
             # TODO allow for other means of privilege escalation
             # TODO allow for other means to bootstrap
-            "sudo singularity build {outputs} {inputs}",
+            "sudo singularity build --force {outputs} {inputs}",
             inputs=[str(recipe.relative_to(builder_ds.pathobj))],
             outputs=[str(buildenv)],
             result_renderer='disabled',

--- a/datalad_debian/configure_builder.py
+++ b/datalad_debian/configure_builder.py
@@ -71,7 +71,6 @@ class ConfigureBuilder(Interface):
         # TODO check if this is an actual builder dataset,
         # and give advice if not
         spec = normalize_specs(spec)
-        print(spec)
 
         tmpl_path = None
         for tp in (

--- a/datalad_debian/resources/recipes/singularity-default
+++ b/datalad_debian/resources/recipes/singularity-default
@@ -2,37 +2,58 @@ Bootstrap:docker
 From:{dockerbase}
 
 %post
-    apt-get -y update
-    apt-get -y install --no-install-recommends build-essential devscripts eatmydata equivs
-    # remove everything but the lock file from
-    # /var/cache/apt/archives/ and /var/cache/apt/archives/partial/
-    apt-get clean
-    # builder setup relies on this particular directory to exist inside the container
-    mkdir /pkg
+
+apt-get -y update
+apt-get -y install --no-install-recommends build-essential devscripts eatmydata equivs moreutils
+# remove everything but the lock file from
+# /var/cache/apt/archives/ and /var/cache/apt/archives/partial/
+apt-get clean
+# builder setup relies on this particular directory to exist inside the container
+mkdir /pkg
+
+cat << EOT > /doall.sh
+set -e -u
+dsc=\$1
+# somehow --containall causes 755 by default
+chmod 777 /tmp
+# all building will take place inside the container
+# maybe add option to do it on the host FS?
+mkdir -p /tmp/build
+# ingest the source package into a defined location in the container env
+dcmd cp "\$dsc" /tmp/build
+# extract the source package
+echo -e "\n#\n# Extracting the source package: \$(date -u --iso-8601=seconds)\n#\n"
+(cd /tmp/build && dpkg-source -x *.dsc source)
+# update the package list, necessary to get the latest build-dependency
+# version
+echo -e "\n#\n# Updating build environment: \$(date -u --iso-8601=seconds)\n#\n"
+chronic eatmydata apt-get update -y
+# update the base environment. needed for rolling releases to stay
+# up-to-date
+chronic eatmydata apt-get upgrade -y
+# install the declared build-dependencies
+echo -e "\n#\n# Installing build-dependencies: \$(date -u --iso-8601=seconds)\n#\n"
+(cd /tmp && mk-build-deps -t 'eatmydata apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y' -i -r /tmp/build/source/debian/control)
+# build the binary package(s)
+echo -e "\n#\n# Build starting: \$(date -u --iso-8601=seconds)\n#\n"
+(cd /tmp/build/source && debuild -uc -us -b)
+# deposit the results
+echo -e "\n#\n# Deposit build results: \$(date -u --iso-8601=seconds)\n#\n"
+dcmd cp /tmp/build/*changes /pkg
+EOT
+
 
 %runscript
-    # we run with -x to get verbose output suitable for a comprehensive
-    # log file
-    set -e -u -x
-    dsc=$1
-    # somehow --containall causes 755 by default
-    chmod 777 /tmp
-    # update the package list, necessary to get the latest build-dependency
-    # version
-    eatmydata apt-get update -y
-    # update the base environment. needed for rolling releases to stay
-    # up-to-date
-    eatmydata apt-get upgrade -y
-    # all building will take place inside the container
-    # maybe add option to do it on the host FS?
-    mkdir -p /tmp/build
-    # ingest the source package into a defined location in the container env
-    dcmd cp "$dsc" /tmp/build
-    # extract the source package
-    (cd /tmp/build && dpkg-source -x *.dsc source)
-    # install the declared build-dependencies
-    (cd /tmp && mk-build-deps -t 'eatmydata apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y' -i -r /tmp/build/source/debian/control)
-    # build the binary package(s)
-    (cd /tmp/build/source && debuild -uc -us -b)
-    # deposit the results
-    dcmd cp /tmp/build/*changes /pkg
+#!/bin/bash
+
+set -e -u
+dsc=$1
+# ISO-like timestamp, but more compact
+ts=$(date --utc --iso-8601=seconds | cut -d '+' -f 1 | tr -d ':-')
+flavor=$(dpkg-architecture -q DEB_BUILD_ARCH_CPU)
+# double-braces are escaping for template placeholder expansion
+logbase="${{dsc%*.dsc}}"
+logfile="/pkg/logs/${{logbase}}_${{ts}}_${{flavor}}.txt"
+mkdir -p /pkg/logs
+bash /doall.sh "$dsc" |& tee "$logfile"
+echo -e "\n#\n# Builder exit: $(date -u --iso-8601=seconds)\n#\n" >> "$logfile"


### PR DESCRIPTION
Logs are placed into a `logs/` directory in the package dataset, with the naming scheme:

```
<sourcepackage-basename>_<timestamp>_<cpuarch>.txt
```

Log files are not put into Git directly (by default), because they can be large and there can be a lot of them.

Filenames are intended to be easily sortable.

Logs identify important steps in the build process and annotate them with timestamps.

The build setup now uses the `chronic` helper to avoid including base environment update information. These are not specific to a particular package build and are only useful in case things fail.

Example build changeset in a package dataset:

```
run(ok): /tmp/mystuff/packages/hello (dataset) [singularity run --bind builder/cache/var...]
add(ok): hello-dbgsym_2.10-2_amd64.deb (file)                                                                                                        
add(ok): hello_2.10-2_amd64.buildinfo (file)                                                                                                         
add(ok): hello_2.10-2_amd64.changes (file)                                                                                                           
add(ok): hello_2.10-2_amd64.deb (file)                                                                                                               
add(ok): logs/hello_2.10-2_20220524T073207_amd64.txt (file)                                                                                          
```

Example build log (shortened):

```
#
# Extracting the source package: 2022-05-24T07:32:07+00:00
#
...
dpkg-source: warning: failed to verify signature on ./hello_2.10-2.dsc
dpkg-source: info: extracting hello in source
dpkg-source: info: unpacking hello_2.10.orig.tar.gz
dpkg-source: info: unpacking hello_2.10-2.debian.tar.xz

#
# Updating build environment: 2022-05-24T07:32:07+00:00
#

<empty unless it explodes>

#
# Installing build-dependencies: 2022-05-24T07:32:11+00:00
#

...

#
# Build starting: 2022-05-24T07:32:14+00:00
#

 dpkg-buildpackage -us -uc -ui -b
dpkg-buildpackage: info: source package hello
dpkg-buildpackage: info: source version 2.10-2
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Santiago Vila <sanvila@debian.org>
 dpkg-source --before-build .
dpkg-buildpackage: info: host architecture amd64
 debian/rules clean
dh clean
...

#
# Deposit build results: 2022-05-24T07:32:29+00:00
#


#
# Builder exit: 2022-05-24T07:32:29+00:00
#
```


- closes #36 
- closes #38 