### PR TITLE
Implement basic build pipeline as a regression test

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ environment:
     - ID: Ubu20
       DTS: datalad_debian
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      INSTALL_SYSPKGS: python3-virtualenv
+      INSTALL_SYSPKGS: python3-virtualenv devscripts moreutils
       # system git-annex is way too old, use better one
       INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
@@ -61,6 +61,8 @@ init:
   - git config --global user.name "Appveyor Almighty"
   - sh: mkdir ~/DLTMP
   - sh: export TMPDIR=~/DLTMP
+  # Ubuntu 20.04 does not have singularity, get a recent one from upstream
+  - sh: (cd ~/DLTMP && wget https://github.com/sylabs/singularity/releases/download/v3.10.0/singularity-ce_3.10.0-focal_amd64.deb && sudo dpkg -i singularity*deb)
 
 install:
   # If a particular Python version is requested, use env setup (using the

--- a/datalad_debian/configure_builder.py
+++ b/datalad_debian/configure_builder.py
@@ -145,6 +145,7 @@ def normalize_specs(specs):
             (tuple(s.split('=', 1)))
             for s in specs
         ]
+    missing = None
     if isinstance(specs, list):
         missing = [i[0] for i in specs if len(i) == 1]
     if missing:

--- a/datalad_debian/tests/test_from_scratch.py
+++ b/datalad_debian/tests/test_from_scratch.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from datalad.tests.utils import (
+    with_tempfile,
+)
+from datalad.api import (
+    Dataset,
+)
+
+
+@with_tempfile
+def test_from_scratch(wdir):
+    da = {'result_renderer': 'disabled'}
+    dist = Dataset(wdir)
+    dist.deb_new_distribution(**da)
+    dist.subdatasets(
+        path='builder',
+        set_property=[('url', str(Path(wdir) / 'builder'))])
+    builder = Dataset(dist.pathobj / 'builder')
+    builder.deb_configure_builder(spec={'dockerbase': 'debian:bullseye'})
+    builder.deb_bootstrap_builder()
+    dist.save(path='builder', message="Update distribution builder")
+    dist.deb_new_package('hello')
+    pkg_hello = Dataset(dist.pathobj / 'packages' / 'hello')
+    pkg_hello.run(
+        "dget -u -d http://deb.debian.org/debian/pool/main/h/hello/hello_2.10-2.dsc",
+        message="Add version 2.10-2 source package")
+    pkg_hello.deb_build_package('hello_2.10-2.dsc')
+    dist.save(path='packages', message="Package update")

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ exclude=
     _datalad_buildsupport
 
 [options.package_data]
-* = resources/procedures/*.py
+* = resources/procedures/*.py, resources/recipes/*
 [options.entry_points]
 # 'datalad.extensions' is THE entrypoint inspected by the datalad API builders
 datalad.extensions =


### PR DESCRIPTION
This enshrines https://github.com/psychoinformatics-de/datalad-debian/issues/12#issuecomment-1133233807 in code, via the Python API

Full from-scratch bootstrapping of everything needed to build debian packages from source, with prov-tracking and container handling via datalad.

Closes #12
Closes #46