### PR TITLE
Add proper error record when builder subds isn't found

### DIFF
--- a/datalad_debian/new_package.py
+++ b/datalad_debian/new_package.py
@@ -60,8 +60,25 @@ class NewPackage(Interface):
             on_failure='ignore',
         )
         # we must have one result for the must-have builder dataset
-        # TODO error nicely if not
-        assert isinstance(builder_info, dict)
+        if builder_info is None:
+            yield dict(
+                action='deb_new_package',
+                status='error',
+                path=dist_ds,
+                message=(
+                    "Failed to find a builder subdataset underneath %s. "
+                    "Make sure to run the command in a distribution "
+                    "superdataset, with a builder configured and created "
+                    "by datalad deb-configure-builder and datalad "
+                    "deb-bootstrap-builder.", dist_ds
+                )
+            )
+            return
+        # unsure if this can ever happen, but if it does, report our confusion
+        if not isinstance(builder_info, dict):
+            raise RuntimeError("Internal error: It seems as if multiple "
+                               "builder subdatasets were found, or they were "
+                               "reported in an unexpected structure.")
 
         # we put all of them in a dedicated directory to have an
         # independent namespace for them that does not conflict with other

--- a/datalad_debian/new_package.py
+++ b/datalad_debian/new_package.py
@@ -61,19 +61,11 @@ class NewPackage(Interface):
         )
         # we must have one result for the must-have builder dataset
         if builder_info is None:
-            yield dict(
-                action='deb_new_package',
-                status='error',
-                path=dist_ds,
-                message=(
-                    "Failed to find a builder subdataset underneath %s. "
-                    "Make sure to run the command in a distribution "
-                    "superdataset, with a builder configured and created "
-                    "by datalad deb-configure-builder and datalad "
-                    "deb-bootstrap-builder.", dist_ds
-                )
-            )
-            return
+            raise RuntimeError(
+                "Failed to find a builder subdataset underneath %s. Make sure "
+                "to run the command in a distribution superdataset, with a "
+                "builder configured & created by datalad deb-configure-builder "
+                "and datalad deb-bootstrap-builder." % dist_ds)
         # unsure if this can ever happen, but if it does, report our confusion
         if not isinstance(builder_info, dict):
             raise RuntimeError("Internal error: It seems as if multiple "


### PR DESCRIPTION
Previously, only an uniformative AssertionError would have been
reported. The error message now hints at the underlying cause for
the error (failure to find a builder subds) and hints at a likely
reason (command wasn't run in the superdataset, or the superdataset
did not yet receive a builder subds), and is an actual datalad
result record.
The old assertion statement is transformed into a second check
which is unlikely to ever error, but if it does, it would hint
at a general problem - either the subdataset result record
would have returned several items, or changed its reporting
structure. In those cases, the function raises a
RuntimeError to prevent downstream errors
Fixes #57.