### PR TITLE
add scriv to development requirements

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,4 +1,5 @@
 # requirements for a development environment
 -e .[devel]
+scriv
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
This PR adds scriv to the development dependencies.

Although it is currently a manual task and therefore a case could be made, that 'scriv' should be provided by the developer, it seems appropriate to provide a complete development environment with the execution of `pip install -r requirements-devel.txt`.
Especially since we might fully automate it in the future.
