### PR TITLE
Promote, document, and test `result_matches()` helper

### DIFF
--- a/datalad_debian/new_distribution.py
+++ b/datalad_debian/new_distribution.py
@@ -18,6 +18,9 @@ from datalad.support.constraints import (
 )
 from datalad.support.param import Parameter
 
+from datalad_debian.utils import result_matches
+
+
 lgr = logging.getLogger('datalad.debian.new_distribution')
 
 
@@ -98,19 +101,3 @@ class NewDistribution(Interface):
             # we leave the flow-control to the caller
             on_failure='ignore',
         )
-
-
-def result_matches(res, **kwargs):
-    # special internal type that could not possibly come from outside
-    # which we can use to streamline our tests here
-    class NotHere():
-        pass
-
-    for k, v in kwargs.items():
-        if not isinstance(v, (list, tuple)):
-            # normalize for "is in" test
-            v = (v,)
-        if res.get(k, NotHere) not in v:
-            # either `k` was not in `res, or the value does not match
-            return False
-    return True

--- a/datalad_debian/tests/test_utils.py
+++ b/datalad_debian/tests/test_utils.py
@@ -1,0 +1,25 @@
+from datalad.tests.utils_pytest import assert_raises
+
+from ..utils import result_matches
+
+
+def test_result_matches():
+    assert_raises(TypeError, result_matches)
+    assert_raises(ValueError, result_matches, 5)
+    assert result_matches({})
+    assert result_matches(dict(random='something'))
+    assert result_matches(dict(random='something'), random='something')
+    assert result_matches(dict(random='something'),
+                          random=('else', 'something'))
+    assert not result_matches(dict(random='something'), random=5)
+    assert not result_matches(dict(random='something'), somekey='something')
+    assert not result_matches(dict(random='something'),
+                              random=('v1', 'v2'))
+    assert result_matches(
+        dict(msg=('text %s', 'value')),
+        msg=(('text %s', 'value'),)
+    )
+    assert result_matches(
+        dict(msg=('text %s', 'value')),
+        msg=[('text %s', 'value'),]
+    )

--- a/datalad_debian/utils.py
+++ b/datalad_debian/utils.py
@@ -1,0 +1,38 @@
+
+
+def result_matches(res, **kwargs) -> bool:
+    """Test whether a (result) dict matches given key/value combinations.
+
+    Parameters
+    ----------
+    res: dict
+      Result dictionary to inspect.
+    **kwargs:
+      key-value pairs to match. For each key, the value in `res` has to
+      match the value to given value. Multiple candidate values can be
+      given as a tuple or a list value for a given key. If the target
+      value in `res` is a tuple or list, the `kwargs` value must be
+      wrapped into a tuple.
+
+    Returns
+    -------
+    bool
+      True if `res` matches all key/value specifications in `kwargs`,
+      and False otherwise.
+    """
+    if not hasattr(res, 'items'):
+        raise ValueError('Argument must be dict-like')
+
+    # special internal type that could not possibly come from outside
+    # which we can use to streamline our tests here
+    class NotHere():
+        pass
+
+    for k, v in kwargs.items():
+        if not isinstance(v, (list, tuple)):
+            # normalize for "is in" test
+            v = (v,)
+        if res.get(k, NotHere) not in v:
+            # either `k` was not in `res, or the value does not match
+            return False
+    return True


### PR DESCRIPTION
This is a candidate for a future migration to datalad-next or
datalad-core.

Closes psychoinformatics-de/datalad-debian#63