### PR TITLE
ENH: Add a commit message to bootstrap builder's datalad run

### DIFF
--- a/datalad_debian/bootstrap_builder.py
+++ b/datalad_debian/bootstrap_builder.py
@@ -75,6 +75,7 @@ class BootstrapBuilder(Interface):
             "sudo singularity build --force {outputs} {inputs}",
             inputs=[str(recipe.relative_to(builder_ds.pathobj))],
             outputs=[str(buildenv)],
+            message=f"Bootstrap builder '{buildenv_name}'",
             result_renderer='disabled',
             return_type='generator',
             # give control flow to caller


### PR DESCRIPTION
This PR adds a commit message to the `datalad run` call responsible for running `singularity_build` within `bootstrap_builder.py`. The message will say "Bootstrap builder '{buildenv_name}'".

This is similar to what the `containers run` produces (except `containers run` can say "configure" or "update").

So the commits created by `deb-bootstrap-builder` would now be (newest first):

```
[DATALAD] Configure containerized environment 'singularity-amd64'
[DATALAD RUNCMD] Bootstrap builder 'singularity-amd64'
```

Closes #40 