### PR TITLE
Utility command `deb-add-distribution`

### DIFF
--- a/datalad_debian/__init__.py
+++ b/datalad_debian/__init__.py
@@ -45,6 +45,12 @@ command_suite = (
             'deb-new-reprepro-repository',
             'deb_new_reprepro_repository',
         ),
+        (
+            'datalad_debian.add_distribution',
+            'AddDistribution',
+            'deb-add-distribution',
+            'deb_add_distribution',
+        ),
     ]
 )
 

--- a/datalad_debian/add_distribution.py
+++ b/datalad_debian/add_distribution.py
@@ -1,0 +1,80 @@
+import logging
+
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.utils import (
+    eval_results,
+)
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.param import Parameter
+
+lgr = logging.getLogger('datalad.debian.add_distribution')
+
+
+@build_doc
+class AddDistribution(Interface):
+    """Create a distribution dataset to an package repository dataset
+    """
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the package repository dataset to add the
+            distribution to""",
+            constraints=EnsureDataset() | EnsureNone()),
+        source=Parameter(
+            args=("source",),
+            metavar='SOURCE',
+            doc="""URL, DataLad resource identifier, local path or instance of
+            distribution dataset to be added""",
+            constraints=EnsureStr()),
+        name=Parameter(
+            args=('name',),
+            metavar='NAME',
+            doc="""name to add the distribution dataset under""",
+            constraints=EnsureStr() | EnsureNone()),
+    )
+
+    _examples_ = []
+
+    @staticmethod
+    @datasetmethod(name='deb_add_distribution')
+    @eval_results
+    def __call__(source, name, *, dataset=None):
+        # - dataset must be distribution-type (needs to have a builder)
+        # - name must be unique (auto-ensured)
+
+        archive_ds = require_dataset(dataset)
+
+        # we put all of them in a dedicated directory to have an
+        # independent namespace for them that does not conflict with other
+        # components of the distribution dataset
+        dist_ds = archive_ds.pathobj / 'distributions' / name
+        if dist_ds.exists():
+            raise ValueError(f"Target path {dist_ds} already exists. "
+                             "Remove first, or choose a different name.")
+
+        # TODO we likely want to change this to a more careful implementation
+        # following the pattern of `new-package`
+        # - clone without registering
+        # - inspect for sanity, is this a distribution dataset that was cloned
+        # - save and inject the source URL into the .gitmodules record
+        yield from archive_ds.clone(
+            source,
+            path=dist_ds,
+            result_filter=None,
+            result_xfm=None,
+            result_renderer='disabled',
+            return_type='generator',
+            # we leave the flow-control to the caller
+            on_failure='ignore',
+        )

--- a/datalad_debian/add_distribution.py
+++ b/datalad_debian/add_distribution.py
@@ -23,12 +23,12 @@ lgr = logging.getLogger('datalad.debian.add_distribution')
 
 @build_doc
 class AddDistribution(Interface):
-    """Create a distribution dataset to an package repository dataset
+    """Add a distribution dataset to a Debian archive repository dataset
     """
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),
-            doc="""specify the package repository dataset to add the
+            doc="""specify the Debian archive repository dataset to add the
             distribution to""",
             constraints=EnsureDataset() | EnsureNone()),
         source=Parameter(
@@ -40,7 +40,8 @@ class AddDistribution(Interface):
         name=Parameter(
             args=('name',),
             metavar='NAME',
-            doc="""name to add the distribution dataset under""",
+            doc="""name to add the distribution dataset under
+            (directory distributions/<name>)""",
             constraints=EnsureStr() | EnsureNone()),
     )
 

--- a/datalad_debian/tests/test_new_reprepro_repository.py
+++ b/datalad_debian/tests/test_new_reprepro_repository.py
@@ -6,7 +6,12 @@ from datalad.tests.utils_pytest import (
     with_tempfile,
 )
 
-from datalad.api import deb_new_reprepro_repository
+from datalad.api import (
+    Dataset,
+    deb_new_reprepro_repository,
+    deb_add_distribution,
+    deb_new_distribution,
+)
 
 ckwa = dict(result_renderer='disabled')
 
@@ -15,16 +20,31 @@ ckwa = dict(result_renderer='disabled')
 def test_new_reprepro_repository(path=None):
     pathobj = Path(path)
     res = deb_new_reprepro_repository(
-        path=path,
+        path=pathobj / 'archive',
         **ckwa)
     assert_in_results(
         res,
-        path=str(pathobj / 'www'),
+        path=str(pathobj / 'archive' / 'www'),
         type='dataset',
     )
     # README points out where distributions need to go
-    assert (pathobj / 'distributions' / 'README').exists()
+    assert (pathobj / 'archive' / 'distributions' / 'README').exists()
     # config placeholder for reprepro-recognized distributions is
     # placed in the dataset as an untracked file
     # the rest is clean
-    assert_repo_status(path, untracked=[pathobj / 'conf' / 'distributions'])
+    assert_repo_status(
+        pathobj / 'archive',
+        untracked=[pathobj / 'archive' / 'conf' / 'distributions'])
+
+    deb_new_distribution(pathobj / 'distribution', **ckwa)
+    deb_add_distribution(
+        # TODO the `clone` call inside cannot handle Path args
+        str(pathobj / 'distribution'),
+        'mydist',
+        dataset=pathobj / 'archive',
+        **ckwa
+    )
+    # check that the distribution dataset ends up in the right place with
+    # the right name and version
+    assert Dataset(pathobj / 'distribution').repo.get_hexsha() \
+        == Dataset(pathobj / 'archive' / 'distributions' / 'mydist').repo.get_hexsha()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ High-level API commands
    deb_new_package
    deb_build_package
    deb_new_reprepro_repository
+   deb_add_distribution
 
 
 Command line reference
@@ -32,6 +33,7 @@ Command line reference
    generated/man/datalad-deb-new-package
    generated/man/datalad-deb-build-package
    generated/man/datalad-deb-new-reprepro-repository
+   generated/man/datalad-deb-add-distribution
 
 
 Indices and tables


### PR DESCRIPTION
To add a distribution dataset to a reprepro/archive dataset in the right location.

Closes psychoinformatics-de/datalad-debian#66