### PR TITLE
DOC: Logos and structure to the docs

### DIFF
--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -1,0 +1,18 @@
+.. _chap_cmdline:
+
+**********************
+Command line reference
+**********************
+
+The order of commands follows their logical order of execution in a start-to-end packaging workflow.
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/datalad-deb-new-distribution
+   generated/man/datalad-deb-configure-builder
+   generated/man/datalad-deb-bootstrap-builder
+   generated/man/datalad-deb-new-package
+   generated/man/datalad-deb-build-package
+   generated/man/datalad-deb-new-reprepro-repository
+   generated/man/datalad-deb-add-distribution

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -124,7 +124,7 @@ html_theme = 'sphinx_rtd_theme'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = '_static/datalad_logo.png'
+html_logo = '_static/datalad_debian_logo.svg'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,6 +2,18 @@ DataLad extension for working with Debian packages and package repositories
 ***************************************************************************
 
 
+
+This software provides functionality to create DataLad-based structures for building and disseminating Debian packages.
+Its major aims are threefold:
+
+- It simplifies the Debian package build process by wrapping a build workflow into DataLad convenience commands
+- With DataLad's provenance capture and version control features, it provides a basis for reproducibly building and updating packages
+- It creates a readily serveable package archive
+
+.. image:: _static/datalad_debian_logo_with_names.svg
+   :width: 50%
+   :align: center
+
 Overview
 ========
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,38 +24,14 @@ Overview
 
 
 
-API
-===
-  
-High-level API commands
------------------------
-  
-.. currentmodule:: datalad.api
-.. autosummary::
-   :toctree: generated
-
-   deb_new_distribution
-   deb_configure_builder
-   deb_bootstrap_builder
-   deb_new_package
-   deb_build_package
-   deb_new_reprepro_repository
-   deb_add_distribution
-
-
-Command line reference
-----------------------
+Commands and API
+================
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   generated/man/datalad-deb-new-distribution
-   generated/man/datalad-deb-configure-builder
-   generated/man/datalad-deb-bootstrap-builder
-   generated/man/datalad-deb-new-package
-   generated/man/datalad-deb-build-package
-   generated/man/datalad-deb-new-reprepro-repository
-   generated/man/datalad-deb-add-distribution
+   cmdline
+   modref
 
 
 Indices and tables

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -1,0 +1,19 @@
+.. _chap_modref:
+
+***********************
+Python module reference
+***********************
+
+The order of commands follows their logical order of execution in a start-to-end packaging workflow.
+
+.. currentmodule:: datalad.api
+.. autosummary::
+   :toctree: generated
+
+   deb_new_distribution
+   deb_configure_builder
+   deb_bootstrap_builder
+   deb_new_package
+   deb_build_package
+   deb_new_reprepro_repository
+   deb_add_distribution


### PR DESCRIPTION
This PR adds @jsheunis logos from #82 into the docs, adds (an attempt) at a high-level summary of the extensions functionality, and makes the side bar less busy by moving CMD and Python API overviews into separate toc tree files. This way, only the expandable main headers "Command line reference" and "Python module reference" are shown instead of all commands at once.
![Screenshot from 2022-07-12 09-39-38](https://user-images.githubusercontent.com/29738718/178435910-d65da7f8-2c69-4bf1-a074-94cdd68b9fa3.png)
