### PR TITLE
add nonfree singularity template

### DIFF
--- a/datalad_debian/configure_builder.py
+++ b/datalad_debian/configure_builder.py
@@ -49,6 +49,10 @@ class ConfigureBuilder(Interface):
 
     - 'singularity-default': A Singularity recipe requiring the spec
       'dockerbase' with a value for the container's base image
+    - 'nonfree': A Singularity recipe requiring the spec
+      'dockerbase' with a value for the container's base image. Compared to
+      'singularity-default', this template environment allows dependencies to
+      nonfree dependencies
     """
 
     _params_ = dict(

--- a/datalad_debian/resources/recipes/singularity-nonfree
+++ b/datalad_debian/resources/recipes/singularity-nonfree
@@ -1,0 +1,63 @@
+Bootstrap:docker
+From:{dockerbase}
+
+%post
+
+# enable nonfree and contrib packages
+sed -i 's/main/main contrib non-free/g' /etc/apt/sources.list
+apt-get -y update
+apt-get -y install --no-install-recommends build-essential devscripts eatmydata equivs moreutils lintian
+# remove everything but the lock file from
+# /var/cache/apt/archives/ and /var/cache/apt/archives/partial/
+apt-get clean
+# builder setup relies on this particular directory to exist inside the container
+mkdir /pkg
+
+cat << EOT > /doall.sh
+set -e -u
+dsc=\$1
+# somehow --containall causes 755 by default
+chmod 777 /tmp
+# all building will take place inside the container
+# maybe add option to do it on the host FS?
+mkdir -p /tmp/build
+# ingest the source package into a defined location in the container env
+dcmd cp "\$dsc" /tmp/build
+# extract the source package
+echo -e "\n#\n# Extracting the source package: \$(date -u --iso-8601=seconds)\n#\n"
+(cd /tmp/build && dpkg-source -x *.dsc source)
+# update the package list, necessary to get the latest build-dependency
+# version
+echo -e "\n#\n# Updating build environment: \$(date -u --iso-8601=seconds)\n#\n"
+chronic eatmydata apt-get update -y
+# update the base environment. needed for rolling releases to stay
+# up-to-date
+chronic eatmydata apt-get upgrade -y
+# install the declared build-dependencies
+echo -e "\n#\n# Installing build-dependencies: \$(date -u --iso-8601=seconds)\n#\n"
+(cd /tmp && mk-build-deps -t 'eatmydata apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y' -i -r /tmp/build/source/debian/control)
+# build the binary package(s)
+echo -e "\n#\n# Build starting: \$(date -u --iso-8601=seconds)\n#\n"
+# we need lintian's allow-root, because we are running as root inside singularity's
+# fakeroot environment
+(cd /tmp/build/source && debuild -uc -us -b --lintian-opts --allow-root)
+# deposit the results
+echo -e "\n#\n# Deposit build results: \$(date -u --iso-8601=seconds)\n#\n"
+dcmd cp /tmp/build/*changes /pkg
+EOT
+
+
+%runscript
+#!/bin/bash
+
+set -e -u
+dsc=$1
+# ISO-like timestamp, but more compact
+ts=$(date --utc --iso-8601=seconds | cut -d '+' -f 1 | tr -d ':-')
+flavor=$(dpkg-architecture -q DEB_BUILD_ARCH_CPU)
+# double-braces are escaping for template placeholder expansion
+logbase="${{dsc%*.dsc}}"
+logfile="/pkg/logs/${{logbase}}_${{ts}}_${{flavor}}.txt"
+mkdir -p /pkg/logs
+bash /doall.sh "$dsc" |& tee "$logfile"
+echo -e "\n#\n# Builder exit: $(date -u --iso-8601=seconds)\n#\n" >> "$logfile"


### PR DESCRIPTION
I'm trying to see what it takes to create a build environment for contrib or nonfree packages. In this PR, I just added a line into the recipe that contains 'nonfree' and 'contrib' in ``/etc/apt/sources.list`` as well. Is this enough, and if not, what else is missing?