### PR TITLE
Addressing #39

### DIFF
--- a/datalad_debian/build_package.py
+++ b/datalad_debian/build_package.py
@@ -25,6 +25,7 @@ from datalad.runner import (
     StdOutCapture,
 )
 from datalad.support.param import Parameter
+from .utils import result_matches
 
 lgr = logging.getLogger('datalad.debian.build_package')
 
@@ -189,11 +190,9 @@ class BuildPackage(Interface):
             on_failure='ignore',
         ):
             # find the logfile
-            if r['status'] == 'ok' and r['action'] == 'add' \
-                    and r['type'] == 'file' \
-                    and r['refds'] == pkg_ds.pathobj.as_posix() \
-                    and r['path'].startswith(r['refds'] + "/logs"):
-
+            if result_matches(r, **dict(status='ok', action='add', type='file',
+                                        refds=pkg_ds.pathobj.as_posix())) and \
+                    r['path'].startswith(r['refds'] + "/logs"):
                 build_log = r['path']
             yield r
 

--- a/datalad_debian/resources/recipes/singularity-default
+++ b/datalad_debian/resources/recipes/singularity-default
@@ -59,3 +59,4 @@ logfile="/pkg/logs/${{logbase}}_${{ts}}_${{flavor}}.txt"
 mkdir -p /pkg/logs
 bash /doall.sh "$dsc" |& tee "$logfile"
 echo -e "\n#\n# Builder exit: $(date -u --iso-8601=seconds)\n#\n" >> "$logfile"
+echo -e "\n#\n# datalad-debian: build succeeded\n#\n" >> "$logfile"


### PR DESCRIPTION
Add a marker at the end of the build log for datalad-debian to discover.
We want `deb-build-package`'s internal `containers-run` call to come
back zero and commit the log, but `deb-build-package` needs to be able
to discover and report that something went wrong.

In opposition to what's described under 1. in https://github.com/psychoinformatics-de/datalad-debian/issues/39#issuecomment-1181529398, we now get this (returns non-zero):
```
❱ datalad deb-build-package hello_2.10-2.dsc                                      
['hello_2.10.orig.tar.gz', 'hello_2.10-2.debian.tar.xz', 'hello_2.10-2.dsc']
[INFO   ] Making sure inputs are available (this may take some time) 
[INFO   ] == Command start (output follows) ===== 
INFO:    Converting SIF file to temporary sandbox...

#
# Extracting the source package: 2022-07-12T12:30:44+00:00
#

dpkg-source: error: invalid line in sha1 checksums string: f7bonc<nöornsufn2a2295e889f66e05ce9bfaed9ace3 725946 hello_2.10.orig.tar.gz
INFO:    Cleaning up image...
[INFO   ] == Command exit (modification check follows) ===== 
run(ok): /tmp/debian-playground/dist/packages/hello (dataset) [singularity run --bind builder/cache/var...]
add(ok): logs/hello_2.10-2_20220712T123044_amd64.txt (file)                                                                                                           
save(ok): . (dataset)                                                                                                                                                 
deb_build_package(error): /tmp/debian-playground/dist/packages/hello (dataset) [Build failed. Check /tmp/debian-playground/dist/packages/hello/logs/hello_2.10-2_20220712T123044_amd64.txt for details.]
action summary:
  add (ok: 1)
  deb_build_package (error: 1)
  get (notneeded: 7)
  run (ok: 1)
  save (notneeded: 1, ok: 1)
```


Not yet unittested