### PR TITLE
DOC: Fix template name in docstring

### DIFF
--- a/datalad_debian/configure_builder.py
+++ b/datalad_debian/configure_builder.py
@@ -47,7 +47,7 @@ class ConfigureBuilder(Interface):
 
     Currently supported templates are
 
-    - 'singularity-default': A Singularity recipe requiring the spec
+    - 'default': A Singularity recipe requiring the spec
       'dockerbase' with a value for the container's base image
     """
 


### PR DESCRIPTION
Realized in #97 that template name do not include the cfgtype.