### PR TITLE
Add ability for optional builder config placeholders

### DIFF
--- a/datalad_debian/configure_builder.py
+++ b/datalad_debian/configure_builder.py
@@ -23,6 +23,11 @@ from datalad.support.param import Parameter
 lgr = logging.getLogger('datalad.debian.configure_builder')
 
 
+spec_defaults = {
+    'debian_archive_sections': 'main',
+}
+
+
 @build_doc
 class ConfigureBuilder(Interface):
     """Configure a package build environment
@@ -47,8 +52,15 @@ class ConfigureBuilder(Interface):
 
     Currently supported templates are
 
-    - 'default': A Singularity recipe requiring the spec
-      'dockerbase' with a value for the container's base image
+    - 'default': A Singularity recipe.
+
+      Required parameters:
+      - 'dockerbase' with a value for the container's base image
+
+      Optional parameters:
+      - 'debian_archive_sections' which sections of the Debian package archive
+        to enable for APT in the build environment. To enable all sections
+        set to 'main contrib non-free'. Default: 'main'
     """
 
     _params_ = dict(
@@ -101,7 +113,14 @@ class ConfigureBuilder(Interface):
 
         # TODO check if this is an actual builder dataset,
         # and give advice if not
-        spec = normalize_specs(spec)
+
+        # template placeholder replacements start with the common defaults
+        # to avoid users having to specify each and everyone, but be able to
+        # override them all, if desired
+        spec = dict(
+            spec_defaults,
+            **normalize_specs(spec)
+        )
 
         tmpl_path = None
         for tp in (

--- a/datalad_debian/configure_builder.py
+++ b/datalad_debian/configure_builder.py
@@ -52,15 +52,16 @@ class ConfigureBuilder(Interface):
 
     Currently supported templates are
 
-    - 'default': A Singularity recipe.
+    Template ``'default'``
 
-      Required parameters:
-      - 'dockerbase' with a value for the container's base image
+    This is a Singularity recipe with the following configuration items:
 
-      Optional parameters:
-      - 'debian_archive_sections' which sections of the Debian package archive
-        to enable for APT in the build environment. To enable all sections
-        set to 'main contrib non-free'. Default: 'main'
+    - ``dockerbase`` (required): name of a Docker base image for the
+      container, i.e. 'debian:bullseye'
+    - ``'debian_archive_sections`` (optional): which sections of the
+      Debian package archive to enable for APT in the build environment.
+      To enable all sections set to 'main contrib non-free'.
+      Default: 'main'
     """
 
     _params_ = dict(

--- a/datalad_debian/configure_builder.py
+++ b/datalad_debian/configure_builder.py
@@ -27,12 +27,12 @@ lgr = logging.getLogger('datalad.debian.configure_builder')
 class ConfigureBuilder(Interface):
     """Configure a package build environment
 
-    A builder is a (containerized) build environment used to build binary Debian
-    packages from source files. This command is typically run in a distribution
-    dataset and configures a builder recipe based on a template and
-    user-specified values for the template's placeholders.
-    The resulting recipe will be placed in the 'recipes/' directory in the
-    'builder/' subdataset of a distribution dataset.
+    A builder is a (containerized) build environment used to build binary
+    Debian packages from Debian source packages. This command is typically run
+    on the builder dataset in a distribution dataset and configures a builder
+    recipe based on a template and user-specified values for the template's
+    placeholders.  The resulting recipe will be placed in the 'recipes/'
+    directory of the builder dataset.
 
     The following directory tree illustrates this.
     The configured builder takes the form of a Singularity recipe here.

--- a/datalad_debian/resources/recipes/singularity-default
+++ b/datalad_debian/resources/recipes/singularity-default
@@ -3,6 +3,7 @@ From:{dockerbase}
 
 %post
 
+sed -i 's,main,{debian_archive_sections},g' /etc/apt/sources.list
 apt-get -y update
 apt-get -y install --no-install-recommends build-essential devscripts eatmydata equivs moreutils lintian
 # remove everything but the lock file from


### PR DESCRIPTION
With this change a builder recipe template can employ placeholders
for which defaults can be made available, hence enabling optional
customization without forcing additional complexity on users.

With the new setup, both of the following call would work with the
same default singulairty recipe template

```
datalad deb-configure-builder dockerbase=mike

datalad deb-configure-builder dockerbase=mike "debian_archive_sections=main contrib non-free"
```

This is an alternative to #97 which required a copy of the recipe template to achieve the same.