### PR TITLE
Build package with singularity using a temporary working dir

### DIFF
--- a/datalad_debian/bootstrap_builder.py
+++ b/datalad_debian/bootstrap_builder.py
@@ -120,6 +120,7 @@ class BootstrapBuilder(Interface):
             '--containall ' \
             '--writable ' \
             '--no-home ' \
+            '--workdir {{tmpdir}} ' \
             '{img} {cmd}'
 
         # this is a fresh addition of the build env


### PR DESCRIPTION
Because we are calling `singularity run` with `--containall` and
`--no-home` to improve isolation from the host environment, we ended
up having a 16 MB tmpfs for `/tmp` inside the container.

Not enough for many builds, because we extract the source package
inside that `/tmp` among other things.

This change declares a dedicated `--workdir` for singularity. It is
pointed to a temporary directory that is automatically provided by
`datalad run`.

With this change `/tmp/build` inside the container is effectively
located on the host filesystem.

Closes psychoinformatics-de/datalad-debian#114