### PR TITLE
Make distribution datasets "noannex"

### DIFF
--- a/datalad_debian/new_distribution.py
+++ b/datalad_debian/new_distribution.py
@@ -77,6 +77,9 @@ class NewDistribution(Interface):
                 dataset=dataset,
                 path=path,
                 force=force,
+                # a distribution dataset is just a container for
+                # (package) subdatasets
+                annex=False,
                 # critical, otherwise create() throws any errors away
                 # https://github.com/datalad/datalad/issues/6695
                 result_filter=None,


### PR DESCRIPTION
There is no obvious usecase for distribution datasets to be actual
annex repos. Having them be that nevertheless needlessly complicates
pushing and hosting. There main purpose of being a registry of
(the state of) package datasets can be achieves as plain git repos.

This change creates distribution datasets as git repos without an annex.

Fixes psychoinformatics-de/datalad-debian#125