### PR TITLE
Faciliate build environment customizations

### DIFF
--- a/datalad_debian/configure_builder.py
+++ b/datalad_debian/configure_builder.py
@@ -42,13 +42,17 @@ class ConfigureBuilder(Interface):
     The following directory tree illustrates this.
     The configured builder takes the form of a Singularity recipe here.
 
-        | bullseye                <- distribution dataset
-        |    ├── builder             <- builder subdataset
+        | bullseye/                          <- distribution dataset
+        |    ├── builder                     <- builder subdataset
         |    │   ├── envs
-        |    │   │   └──  README.md
-        |    │   └── recipes
-        |    │       ├── README.md
-        |    │       └── singularity-any     <- builder configuration
+        |    │   │   └── README.md
+        |    │   ├── recipes
+        |    │   │   ├── README.md
+        |    │   │   └── singularity-any     <- builder configuration
+        |    │   ├── init                    <- additional builder content
+        |    │   │   ├── README.md
+        |    │   │   ├── finalize/           <- post-processing executables
+        |    │   │   └── ...
 
     Currently supported templates are
 
@@ -62,6 +66,18 @@ class ConfigureBuilder(Interface):
       Debian package archive to enable for APT in the build environment.
       To enable all sections set to 'main contrib non-free'.
       Default: 'main'
+
+    Any files placed in ``init/`` will be copied into the build environment
+    when it is being bootstrapped, right after the base operating system was
+    installed. This can be used to, for example, configure additional
+    APT sources, by placing a ``sources.list`` file into
+    ``init/etc/apt/sources.list.d/...``, and a corresponding GPG key into
+    ``init/usr/share/keyrings/...``.
+
+    Any executables placed into ``init/finalize/`` will be executed at the
+    very end of the bootstrapping process. A finalizer (script) could be used
+    to adjust file permissions, or make arbitrary other modifications without
+    having to adjust the environment recipe directly.
     """
 
     _params_ = dict(

--- a/datalad_debian/new_distribution.py
+++ b/datalad_debian/new_distribution.py
@@ -128,9 +128,16 @@ class NewDistribution(Interface):
 
                 for f, c in (
                         (builder_ds.pathobj / 'recipes' / 'README.md',
-                         "This directory contains the recipes for all build pipeline images."),
+                         "This directory contains the recipes for all build"
+                         "pipeline images.\n"),
                         (builder_ds.pathobj / 'envs' / 'README.md',
-                         "This directory contains build pipeline images."),
+                         "This directory contains build pipeline images.\n"),
+                        (builder_ds.pathobj / 'init' / 'README.md',
+                         "Anything in this directory is copied\n"
+                         "into the root of the build environment.\n"
+                         "Executables placed into `/finalize` inside the\n"
+                         "build environment are ran at the very end of\n"
+                         "the bootstrapping process.\n"),
                 ):
                     if not f.exists():
                         f.parent.mkdir(exist_ok=True)
@@ -140,6 +147,10 @@ class NewDistribution(Interface):
                 for f, a in (
                         # all recipes go into Git
                         (repo.pathobj / 'recipes' / '.gitattributes',
+                         [('*', {'annex.largefiles': 'nothing'})]),
+                        # we might want to save these in unlocked state
+                        # but for now simply put them in git
+                        (repo.pathobj / 'init' / '.gitattributes',
                          [('*', {'annex.largefiles': 'nothing'})]),
                         (repo.pathobj / 'envs' / '.gitattributes',
                          [('*.md', {'annex.largefiles': 'nothing'})]),

--- a/datalad_debian/resources/recipes/singularity-default
+++ b/datalad_debian/resources/recipes/singularity-default
@@ -1,6 +1,13 @@
 Bootstrap:docker
 From:{dockerbase}
 
+%setup
+# ingest any initialization files deposited in 'init/'
+# (intentionally not using `cp -L` to be able to
+#  deposit symlinks)
+[ -d init ] && cp -rv init/* ${{SINGULARITY_ROOTFS}}/
+
+
 %post
 
 sed -i 's,main,{debian_archive_sections},g' /etc/apt/sources.list
@@ -44,6 +51,9 @@ echo -e "\n#\n# Build starting: \$(date -u --iso-8601=seconds)\n#\n"
 echo -e "\n#\n# Deposit build results: \$(date -u --iso-8601=seconds)\n#\n"
 dcmd cp /tmp/build/*changes /pkg
 EOT
+
+# look for any finalizer executables and run them
+[ -d /finalize ] && (for finalizer in /finalize/*; do ".${{finalizer}}"; done) || true
 
 
 %runscript


### PR DESCRIPTION
This change makes it possible to simply add files to drop into a build
environment to the builder dataset. This is a generic mechanism, which
also includes "finalizer" executables inside the environment, that can
be used for arbitrary customization -- including common ones, like
adding additional APT sources.

See docs of `deb-configure-builder` for more info.

Closes psychoinformatics-de/datalad-debian#33