### PR TITLE
Enable using multiple distribution dataset for the same distribution

### DIFF
--- a/datalad_debian/add_distribution.py
+++ b/datalad_debian/add_distribution.py
@@ -41,7 +41,11 @@ class AddDistribution(Interface):
             args=('name',),
             metavar='NAME',
             doc="""name to add the distribution dataset under
-            (directory distributions/<name>)""",
+            (directory distributions/<name>). The name should equal the
+            codename of a configured distribution in the archive. If multiple
+            distribution datasets shall target the same distribution, their
+            name can append a '-<flavor-label>' suffix to the distribution
+            codename.""",
             constraints=EnsureStr() | EnsureNone()),
     )
 

--- a/datalad_debian/tests/test_update_reprepro_repository.py
+++ b/datalad_debian/tests/test_update_reprepro_repository.py
@@ -64,7 +64,7 @@ Architectures: source amd64
     deb_add_distribution(
         dataset=archive_ds_p,
         source=str(dist_ds_p),
-        name='bullseye',
+        name='bullseye-schnappeldibappeldizupf',
         **ckwa
     )
     deb_update_reprepro_repository(dataset=archive_ds_p, **ckwa)
@@ -97,7 +97,7 @@ Architectures: source amd64
         action='update_repository.includedsc',
         path=str(archive_ds_p),
         type='dataset',
-        dsc=str(archive_ds_p / 'distributions' / 'bullseye' /
+        dsc=str(archive_ds_p / 'distributions' / 'bullseye-schnappeldibappeldizupf' /
                 'packages' / 'tqdm' / 'tqdm_4.57.0-2.dsc'),
     )
     # update again, this time only add a deb
@@ -116,7 +116,7 @@ Architectures: source amd64
         action='update_repository.includedeb',
         path=str(archive_ds_p),
         type='dataset',
-        deb=str(archive_ds_p / 'distributions' / 'bullseye' /
+        deb=str(archive_ds_p / 'distributions' / 'bullseye-schnappeldibappeldizupf' /
             'packages' / 'tqdm' / 'python3-tqdm_4.64.0-1_all.deb'),
     )
     assert debinpool.exists()

--- a/datalad_debian/update_reprepro_repository.py
+++ b/datalad_debian/update_reprepro_repository.py
@@ -140,7 +140,12 @@ def _get_updates_from_dist(ds, dist_ds, ref):
     for up in updated_pkg_datasets:
         yield from _get_updates_from_pkg(
             ds,
-            dist_ds.pathobj.name,
+            # only use the part in front of the first '-'
+            # as the target distribution label.
+            # the full name could be different, when multiple
+            # distribution packages (maybe with different builders)
+            # are all targeting the same distribution in the archive
+            dist_ds.pathobj.name.split('-', maxsplit=1)[0],
             up,
             ref,
         )


### PR DESCRIPTION
simultaneously in a single archive dataset. Previously, the entire
subdataset name had to be identical to the distribution codename.
Now only the part leading up to the first '-' (dash) needs to match
a codename.

Closes psychoinformatics-de/datalad-debian#115