### PR TITLE
Undo singularity-enforced mounts to enable package upgrades

### DIFF
--- a/datalad_debian/resources/recipes/singularity-default
+++ b/datalad_debian/resources/recipes/singularity-default
@@ -50,6 +50,12 @@ EOT
 #!/bin/bash
 
 set -e -u
+
+# singularity will (likely) try to provide the hosts timezone in the container
+# but this would prevent certain upgrade scenarios (e.g., a tzdata update), so
+# undo this
+umount /usr/share/zoneinfo/Etc/UTC || true
+
 dsc=$1
 # ISO-like timestamp, but more compact
 ts=$(date --utc --iso-8601=seconds | cut -d '+' -f 1 | tr -d ':-')


### PR DESCRIPTION
Our use case is rather non-standard for a container -- we want to alter
the container with different and new software versions. This conflicts
with some of singularity's behaviors.

This changes undoes a mount of a host's timezone data, which prevents
upgrading tzdata inside the container.

Closes psychoinformatics-de/datalad-debian#132