### PR TITLE
BF: docker bookworm uses deb822

### DIFF
--- a/datalad_debian/resources/recipes/singularity-default
+++ b/datalad_debian/resources/recipes/singularity-default
@@ -10,7 +10,7 @@ From:{dockerbase}
 
 %post
 
-sed -i 's,main,{debian_archive_sections},g' /etc/apt/sources.list
+sed -i 's,main,{debian_archive_sections},g' /etc/apt/sources.list || sed -i 's,main,{debian_archive_sections},g' /etc/apt/sources.list.d/debian.sources
 apt-get -y update
 apt-get -y install --no-install-recommends build-essential devscripts eatmydata equivs moreutils lintian
 # remove everything but the lock file from


### PR DESCRIPTION
Unsure if this is an upstream change or an artifact of the debian docker build. All I could find is this discussion:

https://www.mail-archive.com/debian-devel@lists.debian.org/msg370552.html

In any case, bookworm docker images no longer ship /etc/apt/sources.list