### PR TITLE
DOCS: update format for intersphinx_mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,7 +113,7 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/', None)}
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
The pre-Sphinx 1.0 \'intersphinx_mapping\' format is deprecated. See:

https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping